### PR TITLE
Using Generic names Extension Related Operation

### DIFF
--- a/plugins/keplr-plugin.js
+++ b/plugins/keplr-plugin.js
@@ -62,9 +62,9 @@ module.exports = (on, config) => {
 
     // keplr commands
     importKeplrAccount: keplr.importWallet,
-    acceptKeplrAccess: keplr.acceptAccess,
-    confirmKeplrTransaction: keplr.confirmTransaction,
-    setupKeplr: async ({
+    acceptAccess: keplr.acceptAccess,
+    confirmTransaction: keplr.confirmTransaction,
+    setupWallet: async ({
       secretWordsOrPrivateKey,
       password
     }) => {

--- a/plugins/keplr-plugin.js
+++ b/plugins/keplr-plugin.js
@@ -53,15 +53,15 @@ module.exports = (on, config) => {
     initPlaywright: playwright.init,
     assignWindows: playwright.assignWindows,
     assignActiveTabName: playwright.assignActiveTabName,
-    isKeplrWindowActive: playwright.isKeplrWindowActive,
+    isExtensionWindowActive: playwright.isKeplrWindowActive,
     switchToCypressWindow: playwright.switchToCypressWindow,
     clearPlaywright: playwright.clear,
     clearWindows: playwright.clearWindows,
     isCypressWindowActive: playwright.isCypressWindowActive,
-    switchToKeplrWindow: playwright.switchToKeplrWindow,
+    switchToExtensionWindow: playwright.switchToKeplrWindow,
 
     // keplr commands
-    importKeplrAccount: keplr.importWallet,
+    importWallet: keplr.importWallet,
     acceptAccess: keplr.acceptAccess,
     confirmTransaction: keplr.confirmTransaction,
     setupWallet: async ({

--- a/support/commands.js
+++ b/support/commands.js
@@ -396,10 +396,10 @@ Cypress.Commands.add('confirmTransaction', () => {
   return cy.task('confirmTransaction');
 });
 
-Cypress.Commands.add('isKeplrWindowActive', () => {
-  return cy.task('isKeplrWindowActive');
+Cypress.Commands.add('isExtensionWindowActive', () => {
+  return cy.task('isExtensionWindowActive');
 });
 
-Cypress.Commands.add('switchToKeplrWindow', () => {
-  return cy.task('switchToKeplrWindow');
+Cypress.Commands.add('switchToExtensionWindow', () => {
+  return cy.task('switchToExtensionWindow');
 });

--- a/support/commands.js
+++ b/support/commands.js
@@ -376,25 +376,24 @@ Cypress.Commands.add(
 
 // Keplr Commands
 Cypress.Commands.add(
-  'setupKeplr',
+  'setupWallet',
   (
     secretWordsOrPrivateKey = 'orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology',
     password = 'Test1234',
   ) => {
-    return cy.task('setupKeplr', {
+    return cy.task('setupWallet', {
       secretWordsOrPrivateKey,
       password
     });
   },
 );
 
-
-Cypress.Commands.add('acceptKeplrAccess', () => {
-  return cy.task('acceptKeplrAccess');
+Cypress.Commands.add('acceptAccess', () => {
+  return cy.task('acceptAccess');
 });
 
-Cypress.Commands.add('confirmKeplrTransaction', () => {
-  return cy.task('confirmKeplrTransaction');
+Cypress.Commands.add('confirmTransaction', () => {
+  return cy.task('confirmTransaction');
 });
 
 Cypress.Commands.add('isKeplrWindowActive', () => {

--- a/tests/e2e/specs/keplr/keplr-spec.js
+++ b/tests/e2e/specs/keplr/keplr-spec.js
@@ -1,16 +1,16 @@
 /* eslint-disable ui-testing/no-disabled-tests */
 describe('Keplr', () => {
   context('Test commands', () => {
-    it(`setupKeplr should finish Keplr setup using secret words`, () => {
-      cy.setupKeplr().then(setupFinished => {
+    it(`setupWallet should finish Keplr setup using secret words`, () => {
+      cy.setupWallet().then(setupFinished => {
         expect(setupFinished).to.be.true;
       });
     });
 
-    it(`acceptKeplrAccess should accept connection request to Keplr`, () => {
+    it(`acceptAccess should accept connection request to Keplr`, () => {
       cy.visit('/');
       cy.contains('Connect Wallet').click();
-      cy.acceptKeplrAccess().then(taskCompleted => {
+      cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
       });
       cy.get('.card')
@@ -20,9 +20,9 @@ describe('Keplr', () => {
       cy.contains('agoric1p2aqakv3ulz4qfy2nut86j9gx0dx0yw09h96md');
     });
 
-    it(`confirmKeplrTransaction should confirm transaction for token creation (contract deployment) and check tx data`, () => {
+    it(`confirmTransaction click the 'Make an Offer' button successfully to complete the transaction`, () => {
       cy.contains('Make an Offer').click();
-      cy.confirmKeplrTransaction().then(taskCompleted => {
+      cy.confirmTransaction().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
       });
     });

--- a/tests/e2e/specs/keplr/playwright-spec.js
+++ b/tests/e2e/specs/keplr/playwright-spec.js
@@ -7,7 +7,7 @@ describe('Playwright', () => {
     });
     it(`assignActiveTabName should properly assign keplr tab as currently active and verify result using isKeplrWindowActive & isCypressWindowActive`, () => {
       cy.assignActiveTabName('keplr');
-      cy.isKeplrWindowActive().then(isActive => {
+      cy.isExtensionWindowActive().then(isActive => {
         expect(isActive).to.be.true;
       });
       cy.isCypressWindowActive().then(isActive => {
@@ -24,7 +24,7 @@ describe('Playwright', () => {
       cy.isCypressWindowActive().then(isActive => {
         expect(isActive).to.be.true;
       });
-      cy.isKeplrWindowActive().then(isActive => {
+      cy.isExtensionWindowActive().then(isActive => {
         expect(isActive).to.be.false;
       });
     });


### PR DESCRIPTION
The PR does the following:
- Uses generic names for operations-related extensions. This is done to allow flexibility in shifting between extensions and maintaining consistency in test cases. 